### PR TITLE
Fix relocating venvs with multi-line shebangs

### DIFF
--- a/tests/test_virtual_environment.py
+++ b/tests/test_virtual_environment.py
@@ -66,10 +66,9 @@ def test_relocate(venv):
 
         if script.shebang:
 
-            assert script.shebang == ['#!{0}/bin/python{1}'.format(
+            assert script.shebang == '#!{0}/bin/python'.format(
                 path,
-                os.linesep,
-            )]
+            )
 
 
 def test_relocate_long_shebang(venv):
@@ -87,16 +86,20 @@ def test_relocate_long_shebang(venv):
 
     for script in venv.bin.files:
         shebang = script.shebang
-        if shebang and len(shebang) == 1:
-            assert shebang == ['#!{0}/bin/python{1}'.format(
-                path,
-                os.linesep,
-            )]
+        if shebang:
+            shebang = shebang.split(os.linesep)
+            if len(shebang) == 1:
+                assert shebang == ['#!{0}/bin/python'.format(
+                    path
+                )]
 
-        elif shebang and len(shebang) == 3:
-            assert shebang == \
-                   ['#!/bin/sh{0}'.format(os.linesep),
-                    '\'\'\'exec\' {0}/bin/python "$0" "$@"{1}'.format(
-                        path,
-                        os.linesep),
-                    "' '''{0}".format(os.linesep)]
+            elif len(shebang) == 3:
+                assert shebang == \
+                       ['#!/bin/sh',
+                        '\'\'\'exec\' {0}/bin/python "$0" "$@"'.format(
+                            path),
+                        "' '''"]
+
+            else:
+                assert False, "Invalid shebang length: {0}, {1}".format(
+                    len(shebang), script.shebang)

--- a/venvctrl/venv/base.py
+++ b/venvctrl/venv/base.py
@@ -159,8 +159,9 @@ class BinFile(VenvFile):
                     file_handle.read(8) == b"'''exec'"
 
                 file_handle.seek(0)
-                return [next(file_handle).decode('utf8') for _
-                        in range(3 if new_style_shebang else 1)]
+                return os.linesep.join(
+                    [next(file_handle).decode('utf8').strip() for _
+                     in range(3 if new_style_shebang else 1)])
 
         return None
 
@@ -172,11 +173,19 @@ class BinFile(VenvFile):
             ValueError: If the file has no shebang to modify.
             ValueError: If the new shebang is invalid.
         """
+
         if not self.shebang:
 
             raise ValueError('Cannot modify a shebang if it does not exist.')
 
-        if len(self.shebang) != len(new_shebang):
+        if new_shebang is None:
+
+            raise ValueError('New shebang cannot be None.')
+
+        old_shebang = self.shebang.strip().split(os.linesep)
+        new_shebang = new_shebang.strip().split(os.linesep)
+
+        if len(old_shebang) != len(new_shebang):
 
             raise ValueError('Old and new shebangs must '
                              'be same number of lines')

--- a/venvctrl/venv/relocate.py
+++ b/venvctrl/venv/relocate.py
@@ -29,13 +29,20 @@ class RelocateMixin(object):
 
         for binfile in self.bin.files:
 
-            if binfile.shebang and (
-                    'python' in binfile.shebang or 'pypy' in binfile.shebang
+            shebang = binfile.shebang
+            if shebang and len(shebang) == 1 and (
+                    'python' in shebang[0] or 'pypy' in shebang[0]
             ):
-
-                binfile.shebang = '#!{0}'.format(
+                binfile.shebang = ['#!{0}'.format(
+                    os.path.join(destination, 'bin', 'python')
+                )]
+            elif shebang and len(shebang) == 3 and (
+                    'python' in shebang[1] or 'pypy' in shebang[1]
+            ):
+                shebang[1] = '\'\'\'exec\' {0} "$0" "$@"'.format(
                     os.path.join(destination, 'bin', 'python')
                 )
+                binfile.shebang = shebang
 
     def move(self, destination):
         """Reconfigure and move the virtual environment to another path.

--- a/venvctrl/venv/relocate.py
+++ b/venvctrl/venv/relocate.py
@@ -30,19 +30,22 @@ class RelocateMixin(object):
         for binfile in self.bin.files:
 
             shebang = binfile.shebang
-            if shebang and len(shebang) == 1 and (
-                    'python' in shebang[0] or 'pypy' in shebang[0]
-            ):
-                binfile.shebang = ['#!{0}'.format(
-                    os.path.join(destination, 'bin', 'python')
-                )]
-            elif shebang and len(shebang) == 3 and (
-                    'python' in shebang[1] or 'pypy' in shebang[1]
-            ):
-                shebang[1] = '\'\'\'exec\' {0} "$0" "$@"'.format(
-                    os.path.join(destination, 'bin', 'python')
-                )
-                binfile.shebang = shebang
+            if shebang:
+                shebang = shebang.strip().split(os.linesep)
+
+                if len(shebang) == 1 and (
+                        'python' in shebang[0] or 'pypy' in shebang[0]
+                ):
+                    binfile.shebang = '#!{0}'.format(
+                        os.path.join(destination, 'bin', 'python')
+                    )
+                elif len(shebang) == 3 and (
+                        'python' in shebang[1] or 'pypy' in shebang[1]
+                ):
+                    shebang[1] = '\'\'\'exec\' {0} "$0" "$@"'.format(
+                        os.path.join(destination, 'bin', 'python')
+                    )
+                    binfile.shebang = os.linesep.join(shebang)
 
     def move(self, destination):
         """Reconfigure and move the virtual environment to another path.


### PR DESCRIPTION
For virtualenvs with longer paths pip/virtualenv is now using a
multi-line shebang with the actual python path being called on the
second line using exec.

This improves the shebang detection and correctly modifies shebangs
using this newer style syntax.

fixes #4 