### PR TITLE
Fix issues related to .pth rewrite addition

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.rst", "r") as readmefile:
 
 setup(
     name="venvctrl",
-    version="0.4.0",
+    version="0.4.1",
     url="https://github.com/kevinconway/venvctrl",
     description="API for virtual environments.",
     author="Kevin Conway",

--- a/tests/test_virtual_environment.py
+++ b/tests/test_virtual_environment.py
@@ -104,26 +104,26 @@ def test_relocate_long_shebang(venv):
                 )
 
 
-def test_relocate_no_original_path(venv):
-    """Test that the original path is not found in files."""
+def test_relocate_no_original_path_pth(venv):
+    """Test that the original path is not found in .pth files."""
     path = "/testpath"
     original_path = venv.abspath
     f = open(venv.bin.abspath + "/something.pth", "w")
     f.write(original_path)
     f.close()
     venv.relocate(path)
-    dirs = list(venv.dirs)
-    files = list(venv.files)
-    while dirs or files:
-        for file_ in files:
-            with open(file_.abspath, "r") as source:
-                try:
-                    lines = source.readlines()
-                except UnicodeDecodeError:
-                    # Skip any non-text files. Binary files are out of
-                    # scope for this test.
-                    continue
-                for line in lines:
-                    assert original_path not in line, file_.abspath
-        next_dir = dirs.pop()
-        files = list(next_dir.files)
+    dirs = [venv]
+    while dirs:
+        current = dirs.pop()
+        dirs.extend(current.dirs)
+        for file_ in current.files:
+            if file_.abspath.endswith(".pth"):
+                with open(file_.abspath, "r") as source:
+                    try:
+                        lines = source.readlines()
+                    except UnicodeDecodeError:
+                        # Skip any non-text files. Binary files are out of
+                        # scope for this test.
+                        continue
+                    for line in lines:
+                        assert original_path not in line, file_.abspath

--- a/venvctrl/venv/relocate.py
+++ b/venvctrl/venv/relocate.py
@@ -55,10 +55,11 @@ class RelocateMixin(object):
         # site-packages, bundled within an egg directory, or both.
         original_path = self.path
         original_abspath = self.abspath
-        dirs = list(self.dirs)
-        files = list(self.files)
-        while dirs or files:
-            for file_ in files:
+        dirs = [self]
+        while dirs:
+            current = dirs.pop()
+            dirs.extend(current.dirs)
+            for file_ in current.files:
                 if file_.abspath.endswith(".pth"):
                     content = ""
                     with open(file_.abspath, "r") as source:
@@ -72,8 +73,6 @@ class RelocateMixin(object):
                     content = content.replace(original_path, destination)
                     with open(file_.abspath, "w") as source:
                         source.write(content)
-            next_dir = dirs.pop()
-            files = list(next_dir.files)
 
     def move(self, destination):
         """Reconfigure and move the virtual environment to another path.


### PR DESCRIPTION
Fix file discovery to actually recurse the entire virtualenv tree.
Originally, the call to extend the list of directories with
subdirectories was missing. The result was that only top the first two
levels of the directory structure were actually processed. The test is
updated to ensure the full file tree is processed.

The stack of directories was also being mismanaged in a way that could
result in pop from an empty list. Notably, the search would fail when
processing the last batch of files. This was due to the loop condition
which engaged the loop body if there were directory _or_ files to be
processed. If there were only files and all directories had been
consumed then the last iteration would error when trying to pop from the
empty directory list.