### PR TITLE
Bump PyPi version for quote fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.rst", "r") as readmefile:
 
 setup(
     name="venvctrl",
-    version="0.4.1",
+    version="0.4.2",
     url="https://github.com/kevinconway/venvctrl",
     description="API for virtual environments.",
     author="Kevin Conway",


### PR DESCRIPTION
This releases a patch that accounts for virtualenv 20.0.0 and above by
handling both single and double quotes within the activation scripts.