### PR TITLE
Fix for new Nushell sript in virtualenv>=20.14.0

### DIFF
--- a/venvctrl/venv/base.py
+++ b/venvctrl/venv/base.py
@@ -208,10 +208,15 @@ class ActivateFile(BinFile):
     """The virtual environment /bin/activate script."""
 
     read_pattern = re.compile(r"""^VIRTUAL_ENV=["'](.*)["']$""")
-    write_pattern = "VIRTUAL_ENV='{0}'"
 
     def _find_vpath(self):
-        """Find the VIRTUAL_ENV path entry."""
+        """
+        Find the VIRTUAL_ENV path entry.
+
+        Returns:
+            tuple: A tuple containing the matched line, the old vpath, and the line number where the virtual
+            path was found. If the virtual path is not found, returns a tuple of three None values.
+        """
         with open(self.path, "r") as file_handle:
 
             for count, line in enumerate(file_handle):
@@ -219,21 +224,21 @@ class ActivateFile(BinFile):
                 match = self.read_pattern.match(line)
                 if match:
 
-                    return match.group(1), count
+                    return match.group(0), match.group(1), count
 
-        return None, None
+        return None, None, None
 
     @property
     def vpath(self):
         """Get the path to the virtual environment."""
-        return self._find_vpath()[0]
+        return self._find_vpath()[1]
 
     @vpath.setter
     def vpath(self, new_vpath):
         """Change the path to the virtual environment."""
-        _, line_number = self._find_vpath()
-        new_vpath = self.write_pattern.format(new_vpath)
-        self.writeline(new_vpath, line_number)
+        old_line, old_vpath, line_number = self._find_vpath()
+        new_line = old_line.replace(old_vpath, new_vpath)
+        self.writeline(new_line, line_number)
 
 
 class ActivateFishFile(ActivateFile):
@@ -241,7 +246,6 @@ class ActivateFishFile(ActivateFile):
     """The virtual environment /bin/activate.fish script."""
 
     read_pattern = re.compile(r"""^set -gx VIRTUAL_ENV ["'](.*)["']$""")
-    write_pattern = "set -gx VIRTUAL_ENV '{0}'"
 
 
 class ActivateCshFile(ActivateFile):
@@ -249,7 +253,6 @@ class ActivateCshFile(ActivateFile):
     """The virtual environment /bin/activate.csh script."""
 
     read_pattern = re.compile(r"""^setenv VIRTUAL_ENV ["'](.*)["']$""")
-    write_pattern = "setenv VIRTUAL_ENV '{0}'"
 
 
 class ActivateXshFile(ActivateFile):
@@ -257,7 +260,6 @@ class ActivateXshFile(ActivateFile):
     """The virtual environment /bin/activate.xsh script."""
 
     read_pattern = re.compile(r"""^\$VIRTUAL_ENV = r["'](.*)["']$""")
-    write_pattern = '$VIRTUAL_ENV = r"{0}"'
 
 
 class ActivateNuFile(ActivateFile):
@@ -271,7 +273,6 @@ class ActivateNuFile(ActivateFile):
     """
 
     read_pattern = re.compile(r"""^let virtual-env = ["'](.*)["']$""")
-    write_pattern = 'let virtual-env = "{0}"'
 
 
 class ActivateNuFileDeactivateAlias(ActivateFile):
@@ -290,7 +291,6 @@ class ActivateNuFileDeactivateAlias(ActivateFile):
     read_pattern = re.compile(
         r"""^alias deactivate = source ["'](.*)/bin/deactivate.nu["']$"""
     )
-    write_pattern = 'alias deactivate = source "{0}/bin/deactivate.nu"'
 
 
 class BinDir(VenvDir):

--- a/venvctrl/venv/base.py
+++ b/venvctrl/venv/base.py
@@ -298,6 +298,22 @@ class ActivateNuFileDeactivateAlias(ActivateFile):
         r"""^alias deactivate = source ["'](.*)/bin/deactivate.nu["']$"""
     )
 
+    @property
+    def exists(self):
+        """
+        Get if the path exists.
+        
+        Overwite VenvPath property. The /bin/activate.nu scipt generated 
+        by virtualenv>=20.14.0 does contain a virtual path anymore.
+        So, relocation is only required for older versions.
+
+        Returns:
+            bool: True if the /bin/activate.nu exists and it contains a virtual path
+                  for deactivate.
+        """
+
+        return os.path.exists(self.path) and self.vpath is not None
+
 
 class BinDir(VenvDir):
 

--- a/venvctrl/venv/base.py
+++ b/venvctrl/venv/base.py
@@ -270,9 +270,15 @@ class ActivateNuFile(ActivateFile):
     supported shells because it contains two references to the virtualenv path
     rather than one. This is because it requires a specialized deactivate
     script which is aliased to the deactivate command.
+
+    activate.nu:3 generated with virtualenv 20.13.3
+    let virtual-env = "/tmp/test_venv"
+
+    activate.nu:34 generated with virtualenv 20.21.0
+    ....let virtual_env = '/tmp/test_venv'
     """
 
-    read_pattern = re.compile(r"""^let virtual-env = ["'](.*)["']$""")
+    read_pattern = re.compile(r"""^\s*let virtual[-_]env = ["'](.*)["']$""")
 
 
 class ActivateNuFileDeactivateAlias(ActivateFile):


### PR DESCRIPTION
# Pull Request Summary
The pull request fixes issue #23. The Nushell activate and deactivate scripts changed in virtualenv>=20.14.0 and the read_pattern are no longer valid.

For activate the relvant line in `/bin/activate.nu` changed from:
```
let virtual-env = "/tmp/test_venv"
```
to
```
    let virtual_env = '/tmp/test_venv'
```

For deactivate the relvant line in `/bin/activate.nu` changed from:
```
alias deactivate = source "/tmp/test_venv/bin/deactivate.nu"
```
to
```
export alias deactivate = overlay hide activate
```

# Changes Made
1) Support for variation in source file.
In the class `ActivateNuFile`, the `write_pattern` is not used anymore. The matched line is used instead of the `write_pattern`. The `read_pattern` canmatch variation of the source file. The old vpath gets replaced directly in
the matched line by the new vpath. The modified line is written back to the file.

2) Support for new and old activate.nu
Modified the `read_pattern` in the `ActivateNuFile` class from
```
^let virtual-env = ["'](.*)["']$
```
to
```
^\s*let virtual[-_]env = ["'](.*)["']$
```

The new regex pattern matches both, the new and the old format.

3) Support for deactivate in new `activate.nu`
Deactivate does not use a vpath anymore. So, relocation is no longer required. The class `VenvPath` property `exists` has been overwritten in the class `ActivateNuFileDeactivateAlias`. In this class the `exists` property only returns `True` if the file `/bin/activate.nu` exists and the class matches its 'read_pattern'.
