### PR TITLE
Unpin virtualenv dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-virtualenv<=20.11.2
+virtualenv

--- a/venvctrl/venv/base.py
+++ b/venvctrl/venv/base.py
@@ -302,8 +302,8 @@ class ActivateNuFileDeactivateAlias(ActivateFile):
     def exists(self):
         """
         Get if the path exists.
-        
-        Overwite VenvPath property. The /bin/activate.nu scipt generated 
+
+        Overwite VenvPath property. The /bin/activate.nu scipt generated
         by virtualenv>=20.14.0 does contain a virtual path anymore.
         So, relocation is only required for older versions.
 


### PR DESCRIPTION
This reflects the recent patch to fix nushell support. The previous pinning was in place because >=20.11.2 included an unsupported change to nushell activation scripts.