### PR TITLE
Add provisional stdlib venv support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Python 3.7
+      - name: Setup Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Cache PyPI
         uses: actions/cache@v2
         with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        pyver: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: true
     steps:
       - name: Install deps

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.rst", "r") as readmefile:
 
 setup(
     name="venvctrl",
-    version="0.6.0",
+    version="0.7.0",
     url="https://github.com/kevinconway/venvctrl",
     description="API for virtual environments.",
     author="Kevin Conway",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+"""Test fixtures and configuration."""
+
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import uuid
+
+import pytest
+
+from venvctrl import api
+
+
+def pytest_generate_tests(metafunc):
+    if "use_stdlib_venv" in metafunc.fixturenames:
+        metafunc.parametrize("use_stdlib_venv", (True, False))
+
+
+@pytest.fixture(scope="function")
+def random():
+    """Get a random UUID."""
+    return str(uuid.uuid4())
+
+
+@pytest.fixture(scope="function")
+def venv(random, tmpdir, use_stdlib_venv):
+    """Get an initialized venv."""
+    path = str(tmpdir.join(random))
+    v = api.VirtualEnvironment(path)
+    if not use_stdlib_venv:
+        v.create()
+    else:
+        v._execute("python -m venv {0}".format(path))
+    return v

--- a/tests/test_virtual_environment.py
+++ b/tests/test_virtual_environment.py
@@ -7,25 +7,8 @@ from __future__ import unicode_literals
 
 import os
 import subprocess
-import uuid
-
-import pytest
 
 from venvctrl import api
-
-
-@pytest.fixture(scope="function")
-def random():
-    """Get a random UUID."""
-    return str(uuid.uuid4())
-
-
-@pytest.fixture(scope="function")
-def venv(random, tmpdir):
-    """Get an initialized venv."""
-    v = api.VirtualEnvironment(str(tmpdir.join(random)))
-    v.create()
-    return v
 
 
 def test_create(random, tmpdir):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,pyt311,pep8,pyflakes
+envlist = py38,py39,py310,py311,py312,pep8,pyflakes
 
 [testenv]
 deps=


### PR DESCRIPTION
This patch modifies the way the bash activate script is handled to work with both virtualenv and the python3 bundled venv. The venv version had a recent change for windows support that caused it to diverge from how virtualenv solved the same cygwin related problems. So there are now two totally different bash activation scripts depending on which tool you use.

The venv style puts the literal path text in several location whereas every other script in both venv and virtualenv puts the literal text only once in a variable and then references the variable. To change multiple path strings I had to rewrite the path replacement mechanism for bash to bulk rewrite every line that contains the path rather than a targeted line replacement like before.

I'm not sure how much more venv will diverge from virtualenv in the future but this should enable it to work for now.