### PR TITLE
Fix relocation for virtualenv>=20.26.6

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,0 +1,21 @@
+FROM docker.io/ubuntu:latest
+
+RUN apt-get update && apt-get install --yes \
+    curl wget \
+    make git vim less \
+    sudo \
+    bash-completion man \
+    software-properties-common \
+    build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev \
+    python3-pip && \
+    pip install --break-system-packages tox virtualenv
+
+RUN add-apt-repository ppa:deadsnakes/ppa && apt-get update && \
+    apt-get install --yes python3.10 python3.11 python3.12 python3.13 \
+    python3.10-distutils python3.11-distutils \
+    python3-venv python3.10-venv python3.11-venv python3.13-venv python3.13-venv
+
+RUN echo ubuntu ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/ubuntu \
+    && chmod 0440 /etc/sudoers.d/ubuntu

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+    "name": "venvctrl",
+    "build": {
+        "dockerfile": "Containerfile",
+        "context": ".."
+    },
+    "remoteUser": "ubuntu",
+    "updateRemoteUserUID": true,
+    "containerEnv": {},
+    "mounts": [],
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "telemetry.telemetryLevel": "off",
+                "telemetry.enableTelemetry": false,
+                "files.insertFinalNewline": true,
+                "files.trimTrailingWhitespace": true,
+                "terminal.integrated.profiles.linux": {
+                    "bash": {
+                        "path": "/usr/bin/bash"
+                    }
+                },
+                "terminal.integrated.defaultProfile.linux": "bash"
+            },
+            "extensions": [
+                "ms-python.python",
+                "redhat.vscode-yaml"
+            ]
+        }
+    }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Cache PyPI
         uses: actions/cache@v2
         with:
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyver: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        pyver: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: true
     steps:
       - name: Install deps
@@ -80,10 +80,10 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install pypa/build
         run: python -m pip install build
       - name: Build a binary wheel and a source tarball

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.rst", "r") as readmefile:
 
 setup(
     name="venvctrl",
-    version="0.7.0",
+    version="0.8.0",
     url="https://github.com/kevinconway/venvctrl",
     description="API for virtual environments.",
     author="Kevin Conway",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312,pep8,pyflakes
+envlist = py39,py310,py311,py312,py313,prequote_virtualenv,pep8,pyflakes
 
 [testenv]
 deps=
@@ -16,3 +16,13 @@ commands=
 commands=
     pyflakes venvctrl/
     pyflakes tests/
+
+[testenv:prequote_virtualenv]
+# Version 20.26.6 of virtualenv changed the activation scripts to no longer
+# include quotes around the rendered paths. This test installs the last version
+# that includes quoted paths.
+deps=
+    virtualenv<=20.26.5
+    -rrequirements.txt
+    -rtest-requirements.txt
+commands=py.test tests/

--- a/venvctrl/venv/base.py
+++ b/venvctrl/venv/base.py
@@ -281,8 +281,8 @@ class ActivateFileBash(ActivateFile):
     activation scripts for bash.
     """
 
-    read_pattern = re.compile(r"""^VIRTUAL_ENV=["'](.*)["']$""")
-    read_pattern_stdlib_venv = re.compile(r"""^ *export VIRTUAL_ENV=["'](.*)["']$""")
+    read_pattern = re.compile(r"""^VIRTUAL_ENV=["']?(.*)["']?$""")
+    read_pattern_stdlib_venv = re.compile(r"""^ *export VIRTUAL_ENV=["']?(.*)["']?$""")
 
     def _find_vpath(self):
         """
@@ -329,21 +329,21 @@ class ActivateFishFile(ActivateFile):
 
     """The virtual environment /bin/activate.fish script."""
 
-    read_pattern = re.compile(r"""^set -gx VIRTUAL_ENV ["'](.*)["']$""")
+    read_pattern = re.compile(r"""^set -gx VIRTUAL_ENV ["']?(.*)["']?$""")
 
 
 class ActivateCshFile(ActivateFile):
 
     """The virtual environment /bin/activate.csh script."""
 
-    read_pattern = re.compile(r"""^setenv VIRTUAL_ENV ["'](.*)["']$""")
+    read_pattern = re.compile(r"""^setenv VIRTUAL_ENV ["']?(.*)["']?$""")
 
 
 class ActivateXshFile(ActivateFile):
 
     """The virtual environment /bin/activate.xsh script."""
 
-    read_pattern = re.compile(r"""^\$VIRTUAL_ENV = r["'](.*)["']$""")
+    read_pattern = re.compile(r"""^\$VIRTUAL_ENV = r["']?(.*)["']?$""")
 
 
 class ActivateNuFile(ActivateFile):
@@ -362,7 +362,7 @@ class ActivateNuFile(ActivateFile):
     ....let virtual_env = '/tmp/test_venv'
     """
 
-    read_pattern = re.compile(r"""^\s*let virtual[-_]env = ["'](.*)["']$""")
+    read_pattern = re.compile(r"""^\s*let virtual[-_]env = r?\#?["']?(.*)["']?\#?$""")
 
 
 class ActivateNuFileDeactivateAlias(ActivateFile):


### PR DESCRIPTION
Virtualenv versions 20.26.6 and greater include a change to the activate script templates. Previously, the full path to the virtualenv that is rendered into the activation script was quoted. The newer versions render unquoted paths. The regular expressions used to match these paths now conditionally matches the quotes which should work for both old and new activation scripts.