### PR TITLE
Fix handling of venv bash activation scripts

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -13,9 +13,9 @@ RUN apt-get update && apt-get install --yes \
     pip install --break-system-packages tox virtualenv
 
 RUN add-apt-repository ppa:deadsnakes/ppa && apt-get update && \
-    apt-get install --yes python3.10 python3.11 python3.12 python3.13 \
+    apt-get install --yes python3.9 python3.10 python3.11 python3.12 python3.13 \
     python3.10-distutils python3.11-distutils \
-    python3-venv python3.10-venv python3.11-venv python3.13-venv python3.13-venv
+    python3-venv python3.9-venv python3.10-venv python3.11-venv python3.13-venv python3.13-venv
 
 RUN echo ubuntu ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/ubuntu \
     && chmod 0440 /etc/sudoers.d/ubuntu

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.rst", "r") as readmefile:
 
 setup(
     name="venvctrl",
-    version="0.8.0",
+    version="0.9.0",
     url="https://github.com/kevinconway/venvctrl",
     description="API for virtual environments.",
     author="Kevin Conway",


### PR DESCRIPTION
The regular expression used to capture the venv's path in a bash activation script was capturing too much. This caused the rewrite that happens during relocate to leave an instance of original path but only in a branch of bash code that is activated when running on Windows.

This patch fixes a bug that was actually present in all regular expressions used to find paths in activation scripts. The bug was previously benign because all virtualenv activation scripts and all but the bash script for venv contain exactly one instance of the matched path which was correctly changed during relocation. Now all scripts use an improved pattern and will automatically handle multiple path instances if they appear over time.