### PR TITLE
Match cygpath in venv bash activation scripts

### DIFF
--- a/venvctrl/venv/base.py
+++ b/venvctrl/venv/base.py
@@ -347,7 +347,7 @@ class ActivateFileBash(ActivateFile):
     # the activation scripts are consistent with quoting so this didn't affect
     # functionality but I fixed it anyway by making the capture group used to
     # extract the path valid only for non-quote characters with `([^"']*)`.
-    read_pattern = re.compile(r"""^\s*(?:export)?\s*VIRTUAL_ENV=\s*["']?([^"']*)["']?$""")
+    read_pattern = re.compile(r"""^\s*(?:export)?\s*VIRTUAL_ENV=\s*(?:\$\(cygpath\s*)?["']?([^"'\)]*)["']?\)?$""")
 
 
 class ActivateFishFile(ActivateFile):


### PR DESCRIPTION
python 3.12.8 is starting to create activation scripts without quotes. This make the regex match $(cygpath ....) as the virtualenv path.

By optionally matching the cygpath command, we make sure it is never included in the regex group.

Fixes #37